### PR TITLE
Refactor the handling of hiding and showing the mouse cursor as well …

### DIFF
--- a/SuperTrashBoy/Assets/Scripts/Inputs/InputManager.cs
+++ b/SuperTrashBoy/Assets/Scripts/Inputs/InputManager.cs
@@ -27,7 +27,6 @@ public class InputManager : MonoBehaviour
         }
         playerControls = new PlayerControls();
 
-        Cursor.visible = false;
     }
 
     private void OnEnable() 

--- a/SuperTrashBoy/Assets/Scripts/Player/Control/CinemachinePOVExtension.cs
+++ b/SuperTrashBoy/Assets/Scripts/Player/Control/CinemachinePOVExtension.cs
@@ -19,7 +19,6 @@ public class CinemachinePOVExtension : CinemachineExtension
     {
         inputManager = InputManager.Instance;
         base.Awake();
-        Cursor.visible = false;
     }
 
     protected override void PostPipelineStageCallback(CinemachineVirtualCameraBase vcam, CinemachineCore.Stage stage, ref CameraState state, float deltaTime)

--- a/SuperTrashBoy/Assets/Scripts/SceneManagement/CreditsRoll.cs
+++ b/SuperTrashBoy/Assets/Scripts/SceneManagement/CreditsRoll.cs
@@ -28,6 +28,7 @@ public class CreditsRoll : MonoBehaviour
         WaitForSeconds ws = new WaitForSeconds(1);
         Scrollbar vs = scrollerView.verticalScrollbar;
 
+        Cursor.lockState = CursorLockMode.Locked;
         while (vs.value >= 0)
         {
             vs.value -= Time.deltaTime / scrollFactor;
@@ -36,6 +37,8 @@ public class CreditsRoll : MonoBehaviour
             yield return wf;
         }
         Invoke(nameof(Start), 2f);
+        Cursor.lockState = CursorLockMode.Confined;
+
         yield return null;
     }
 }

--- a/SuperTrashBoy/Assets/Scripts/SceneManagement/Intro.cs
+++ b/SuperTrashBoy/Assets/Scripts/SceneManagement/Intro.cs
@@ -25,6 +25,8 @@ public class Intro : MonoBehaviour
 
     protected IEnumerator DynamicIntroSequence(Fader fader)
     {
+        Cursor.lockState = CursorLockMode.Locked;
+        Cursor.visible = false;
         fader.FadeOutImmediate();
 
         foreach (Transform t in transform)
@@ -51,6 +53,8 @@ public class Intro : MonoBehaviour
 
         yield return new WaitForSeconds(mainMenuTime);
         yield return fader.FadeIn(mainMenuFadeInTime);
+        Cursor.lockState = CursorLockMode.Confined;
+        Cursor.visible = true;
         Invoke(nameof(Start), 1f);
     }
 

--- a/SuperTrashBoy/Assets/Scripts/SceneManagement/MySceneManager.cs
+++ b/SuperTrashBoy/Assets/Scripts/SceneManagement/MySceneManager.cs
@@ -40,12 +40,14 @@ public class MySceneManager : MonoBehaviour
         cachedTimeScale = Time.timeScale;
         Time.timeScale = 0;
         Cursor.visible = true;
+        Cursor.lockState = CursorLockMode.Confined;
     }
 
     public void ResumeGame()
     {
         Time.timeScale = cachedTimeScale;
         Cursor.visible = false;
+        Cursor.lockState = CursorLockMode.Locked;
     }
 
     public void ReloadCurrentScene()
@@ -85,6 +87,7 @@ public class MySceneManager : MonoBehaviour
 
     public void LoadDummyScene()
     {
+        Debug.Log("load the dummy scene");
         StartCoroutine(LoadScene(1));
     }
 
@@ -100,6 +103,8 @@ public class MySceneManager : MonoBehaviour
 
     private IEnumerator LoadScene(int sceneIndex)
     {
+        Cursor.lockState = CursorLockMode.Locked;
+
         yield return fader.FadeOut(loadSceneFadeOutTime);
         audioManager.StopMusic();
         AsyncOperation asyncLoad = SceneManager.LoadSceneAsync(sceneIndex);
@@ -113,6 +118,7 @@ public class MySceneManager : MonoBehaviour
         // Also, if we return after the game is finished, this will run the outro sequence.
         if (0 == sceneIndex)
         {
+            Cursor.lockState = CursorLockMode.Confined;
             HookupMenuScenePanels();
             if (willPlayOutroSequence)
             {

--- a/SuperTrashBoy/Assets/Scripts/SceneManagement/Outro.cs
+++ b/SuperTrashBoy/Assets/Scripts/SceneManagement/Outro.cs
@@ -27,6 +27,7 @@ public class Outro : MonoBehaviour
     protected IEnumerator DynamicOutroSequence(Fader fader)
     {
         fader.FadeOutImmediate();
+        Cursor.lockState = CursorLockMode.Locked;
 
         foreach (Transform t in transform)
         {
@@ -59,6 +60,7 @@ public class Outro : MonoBehaviour
         }
         else
         {
+            Cursor.lockState = CursorLockMode.Confined;
             Invoke(nameof(Start), 1f);
         }
     }


### PR DESCRIPTION
…as adding lock states for it

Now, when we don't want the mouse for clicking we hide the cursor and lock it so mouse movement input will only translate into turning the view. as soon as regular mouse input is required (showing the main menu or the pause screen) we unlock and unhide the cursor.